### PR TITLE
feat: add env-file input to laravel-setup; make node-version required

### DIFF
--- a/.github/actions/laravel-setup/action.yml
+++ b/.github/actions/laravel-setup/action.yml
@@ -56,12 +56,14 @@ runs:
     - name: Set up Laravel environment
       if: inputs.env-file != ''
       shell: bash
+      env:
+        ENV_FILE: ${{ inputs.env-file }}
       run: |
-        if [ ! -f "${{ inputs.env-file }}" ]; then
-          echo "Error: ${{ inputs.env-file }} file not found."
+        if [ ! -f "$ENV_FILE" ]; then
+          echo "Error: $ENV_FILE file not found."
           exit 1
         fi
-        cp "${{ inputs.env-file }}" .env
+        cp "$ENV_FILE" .env
 
     - name: Install Composer Dependencies
       uses: ramsey/composer-install@v3

--- a/.github/actions/laravel-setup/action.yml
+++ b/.github/actions/laravel-setup/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: 'PHP coverage driver (e.g., xdebug, none)'
     required: false
     default: 'none'
+  env-file:
+    description: 'Environment file to copy to .env (e.g., .env.example, .env.testing)'
+    required: false
 
 runs:
   using: composite
@@ -51,13 +54,14 @@ runs:
       run: npm ci --no-scripts
 
     - name: Set up Laravel environment
+      if: inputs.env-file != ''
       shell: bash
       run: |
-        if [ ! -f .env.ci ]; then
-          echo "Error: .env.ci file not found. This file is required for the test environment."
+        if [ ! -f "${{ inputs.env-file }}" ]; then
+          echo "Error: ${{ inputs.env-file }} file not found."
           exit 1
         fi
-        cp .env.ci .env
+        cp "${{ inputs.env-file }}" .env
 
     - name: Install Composer Dependencies
       uses: ramsey/composer-install@v3

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,9 +5,8 @@ on:
     inputs:
       node-version:
         description: 'Node.js version to be used.'
-        required: false
+        required: true
         type: string
-        default: '20.18.0'
       extensions:
         description: 'File extensions to be linted.'
         required: false

--- a/.github/workflows/laravel-deploy.yml
+++ b/.github/workflows/laravel-deploy.yml
@@ -33,6 +33,10 @@ on:
         description: 'Path to production folder.'
         required: true
         type: string
+      env-file:
+        description: 'Environment file to copy to .env (e.g., .env.ci, .env.example, .env.testing)'
+        required: false
+        type: string
     secrets:
       composer-auth:
         description: 'Credentials used to access private Composer repositories'
@@ -53,21 +57,19 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Laravel
-        uses: dascentral/reusable-workflows/.github/actions/laravel-setup@v0.4.2
+        uses: dascentral/reusable-workflows/.github/actions/laravel-setup@v0.7.0
         with:
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}
           composer-auth: ${{ secrets.composer-auth }}
           composer-dev: 'false'
-
-      - name: Generate application key
-        run: php artisan key:generate
+          env-file: ${{ inputs.env-file }}
 
       - name: Build front-end assets
         run: npm run build
 
       - name: Set up SSH
-        uses: dascentral/reusable-workflows/.github/actions/ssh-setup@v0.4.2
+        uses: dascentral/reusable-workflows/.github/actions/ssh-setup@v0.7.0
         with:
           ssh-private-key: ${{ secrets.ssh-private-key }}
           ssh-host: ${{ inputs.ssh-host }}

--- a/.github/workflows/laravel-tests.yml
+++ b/.github/workflows/laravel-tests.yml
@@ -9,14 +9,17 @@ on:
         type: string
       node-version:
         description: 'Node.js version to be used.'
-        required: false
+        required: true
         type: string
-        default: '24.11.0'
       mysql-image:
         description: 'MySQL image to be used.'
         required: false
         type: string
         default: 'mysql:8'
+      env-file:
+        description: 'Environment file to copy to .env (e.g., .env.example, .env.testing)'
+        required: false
+        type: string
     secrets:
       composer-auth:
         description: 'Credentials used to access private Composer repositories'
@@ -51,19 +54,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v6
 
-      - name: Copy .env.ci to .env
-        run: |
-          if [ -f .env.ci ]; then
-            cp .env.ci .env
-          fi
-
       - name: Set up Laravel
-        uses: dascentral/reusable-workflows/.github/actions/laravel-setup@v0.4.2
+        uses: dascentral/reusable-workflows/.github/actions/laravel-setup@v0.7.0
         with:
           php-version: ${{ inputs.php-version }}
           node-version: ${{ inputs.node-version }}
           php-coverage: xdebug
           composer-auth: ${{ secrets.composer-auth }}
+          env-file: ${{ inputs.env-file }}
 
       - name: Generate application key
         run: php artisan key:generate

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -5,9 +5,8 @@ on:
     inputs:
       node-version:
         description: 'Node.js version to be used.'
-        required: false
+        required: true
         type: string
-        default: '20.12.0'
 
 jobs:
   prettier:


### PR DESCRIPTION
- Replaces the hardcoded `.env.ci` path in `laravel-setup` with a configurable `env-file` input; the env copy step is skipped when no file is specified
- Removes stale `node-version` defaults from all workflows, requiring callers to declare it explicitly
- Removes the unnecessary `key:generate` step from `laravel-deploy`
- Updates action references to `v0.7.0` in `laravel-tests` and `laravel-deploy`